### PR TITLE
feature:remove space after break lines #7

### DIFF
--- a/kelex-memorize/Commands/AddItem.cs
+++ b/kelex-memorize/Commands/AddItem.cs
@@ -40,7 +40,12 @@ namespace kelex_memorize.Commands
                     return;
                 }
 
-                context.QuestionsAndAnswers.Add(new QuestionAndAnswer { Question = question, Answer = answer, Deck = deck });
+                var formatedAnswer = answer;
+				if (answer.Contains("\\n")){
+                    formatedAnswer = String.Join("\n", answer.Split(new[] { "\\n" }, StringSplitOptions.RemoveEmptyEntries).Select(a => a.Trim()));
+                }
+
+                context.QuestionsAndAnswers.Add(new QuestionAndAnswer { Question = question, Answer = formatedAnswer, Deck = deck });
                 context.SaveChanges();
 
                 Console.WriteLine("Question has added successfully!");


### PR DESCRIPTION
Previsouly we need put phrases with line breaks without a space where
was difficult to read.

Example:

```
kelex-memorize.exe add -q "Hardly" -a "It's like almost not.\nI can
hardly find the words" -d "Words"
```

Now we can put space bettwen phrases

```
kelex-memorize.exe add -q "Hardly" -a "It's like almost not. \n I can
hardly find the words" -d "Words"
```